### PR TITLE
Get fhir info

### DIFF
--- a/apps/smart-on-fhir/src/app/context/fhirContext.tsx
+++ b/apps/smart-on-fhir/src/app/context/fhirContext.tsx
@@ -8,6 +8,10 @@ import { IPatient } from '@ahryman40k/ts-fhir-types/lib/R4';
 type ContextProps = {
   client: Client;
   patient: IPatient;
+  user:
+    | fhirclient.FHIR.Patient
+    | fhirclient.FHIR.Practitioner
+    | fhirclient.FHIR.RelatedPerson;
   error: Error;
 };
 export const FhirContext = React.createContext<Partial<ContextProps>>({});
@@ -24,6 +28,11 @@ export const FhirContextProvider = (props: any) => {
   const location = useLocation();
   const [client, setClient] = useState<Client>();
   const [patient, setPatient] = useState<IPatient>();
+  const [user, setUser] = useState<
+    | fhirclient.FHIR.Patient
+    | fhirclient.FHIR.Practitioner
+    | fhirclient.FHIR.RelatedPerson
+  >();
   const [error, setError] = useState<Error>();
 
   useEffect(() => {
@@ -39,6 +48,8 @@ export const FhirContextProvider = (props: any) => {
       if (oauth2Client) {
         const rawPatient = await oauth2Client.patient.read();
         setPatient(rawPatient);
+        const rawUser = await oauth2Client.user.read();
+        setUser(rawUser);
       }
     }
 
@@ -52,6 +63,7 @@ export const FhirContextProvider = (props: any) => {
     client,
     error,
     patient,
+    user,
   };
   return (
     <FhirContext.Provider value={context}>

--- a/apps/smart-on-fhir/src/app/utils/getPatientId.spec.ts
+++ b/apps/smart-on-fhir/src/app/utils/getPatientId.spec.ts
@@ -1,0 +1,44 @@
+import { getPatientId } from './getPatientId';
+import { IPatient, HumanNameUseKind } from '@ahryman40k/ts-fhir-types/lib/R4';
+
+test('it should get a patient id', async () => {
+  const patient: IPatient = {
+    resourceType: 'Patient',
+    name: [
+      {
+        use: HumanNameUseKind._official,
+        family: 'Kshlerin',
+        given: ['Danae'],
+        prefix: ['Mrs.'],
+      },
+      {
+        use: HumanNameUseKind._maiden,
+        family: 'Graham',
+        given: ['Danae'],
+        prefix: ['Mrs.'],
+      },
+    ],
+    identifier: [
+      {
+        system: 'https://github.com/synthetichealth/synthea',
+        value: '1a43c86e-bb91-4573-b571-c87a5e03ead2',
+      },
+      {
+        type: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
+              code: 'SS',
+              display: 'Social Security Number',
+            },
+          ],
+          text: 'Social Security Number',
+        },
+        system: 'http://hl7.org/fhir/sid/us-ssn',
+        value: '999-16-8513',
+      },
+    ],
+  };
+  const patientId = getPatientId('Social Security Number', patient);
+  expect(patientId).toBe('999-16-8513');
+});

--- a/apps/smart-on-fhir/src/app/utils/getPatientId.ts
+++ b/apps/smart-on-fhir/src/app/utils/getPatientId.ts
@@ -1,0 +1,18 @@
+import { IPatient } from '@ahryman40k/ts-fhir-types/lib/R4';
+
+/**
+ * Code to find the wanted identifier. Might have to be changed later,
+ * but that depends on how "Fødselsnummer" is included in patient.
+ * @param patient A Patient resource, to which we wish to find the id
+ * @param typeOfId What type of Id (e.g. "Social Security Number",
+ * "Fødselsnummer", "D-nummer")
+ * @returns A patient id as a string, og an empty string.
+ */
+export const getPatientId = (typeOfId: string, patient?: IPatient) => {
+  if (patient && patient.identifier) {
+    return patient.identifier.find(
+      (identifier) => identifier.type?.text === typeOfId
+    )?.value;
+  }
+  return '';
+};

--- a/apps/smart-on-fhir/src/app/utils/getPatientName.spec.ts
+++ b/apps/smart-on-fhir/src/app/utils/getPatientName.spec.ts
@@ -20,5 +20,5 @@ test('it should get a patient name', async () => {
     ],
   };
   const patientName = getPatientName(patient);
-  expect(patientName).toBe("Danae Kshlerin");
+  expect(patientName).toBe('Danae Kshlerin');
 });

--- a/apps/smart-on-fhir/src/app/utils/getUsersName.spec.ts
+++ b/apps/smart-on-fhir/src/app/utils/getUsersName.spec.ts
@@ -1,0 +1,17 @@
+import { fhirclient } from 'fhirclient/lib/types';
+import { getUsersName } from './getUsersName';
+
+test('it should get a users name name', async () => {
+  const patient: fhirclient.FHIR.Practitioner = {
+    resourceType: 'Practitioner',
+    name: [
+      {
+        family: 'Huels',
+        given: ['Tiesha', 'Doe'],
+        prefix: ['Dr.'],
+      },
+    ],
+  };
+  const patientName = getUsersName(patient);
+  expect(patientName).toBe('Tiesha Doe Huels');
+});

--- a/apps/smart-on-fhir/src/app/utils/getUsersName.ts
+++ b/apps/smart-on-fhir/src/app/utils/getUsersName.ts
@@ -1,0 +1,26 @@
+import { fhirclient } from 'fhirclient/lib/types';
+
+/**
+ * This function gets the users full name. The use will typically be
+ * a Practitioner in EHRs. The function might have to be chenged,
+ * depending on how a Practitioner resouce looks at DIPS and other EHRs.
+ * It currently gives the first name in the user.name array.
+ * @param user The user whos name we would like to know.
+ * @returns A string with the users full name.
+ */
+export const getUsersName = (
+  user:
+    | fhirclient.FHIR.Patient
+    | fhirclient.FHIR.Practitioner
+    | fhirclient.FHIR.RelatedPerson
+    | undefined
+) => {
+  if (user && user.name) {
+    const nameObject = user.name[0];
+    let fullName: string = '';
+    nameObject.given?.map((name: string) => (fullName += name + ' '));
+    fullName += nameObject?.family;
+    return fullName;
+  }
+  return '';
+};


### PR DESCRIPTION
Fixes issue #23 and some of #25, but there are still some information missing because it depends on how a Practitioner and Patient resource is (e.g. how they solve fødselsnummer, HPR-number etc.). Some functions currently work with the SMART launcher, but might have to be changed later. 